### PR TITLE
encrypt: update to secretbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cases. Two particular caveats to the strict copy & paste strategy are:
 
 ## Recommendations
 
-Encryption: 256-bit AES-GCM with random 96-bit nonces
+Encryption: nacl secretbox with random 192-bit nonces
 
 Hashing: SHA-512/256 (preferred) or SHA-256 (compatible)
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,65 +1,71 @@
-// Provides symmetric authenticated encryption using 256-bit AES-GCM with a
-// random nonce.
-
+// Provides symmetric authenticated encryption using nacl secretbox with a
+// random nonce. The length of the message is not hidden.
 package cryptopasta
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
+	"errors"
+	"strconv"
+
+	"golang.org/x/crypto/nacl/secretbox"
 )
 
-const aesKeySize = 32 // force 256-bit AES
+const (
+	KeySize   = 32                 // 256-bit secretbox keys
+	NonceSize = 24                 // 192-bit secretbox nonces
+	Overhead  = secretbox.Overhead // the size of the poly1305 tag
+)
+
+type KeySizeError int
+
+func (err KeySizeError) Error() string {
+	return "cryptopasta/encrypt: invalid key size " + strconv.Itoa(int(err))
+}
 
 // GenerateEncryptionKey generates a random 256-bit key for Encrypt() and
 // Decrypt().
 func GenerateEncryptionKey() ([]byte, error) {
-	return generateBytes(aesKeySize)
+	return generateBytes(KeySize)
 }
 
-// Encrypt encrypts data using 256-bit AES-GCM.  This both hides the content of
-// the data and provides a check that it hasn't been altered.  Output takes the
-// form nonce|ciphertext|tag where '|' indicates concatenation.
+// Encrypt encrypts data using nacl secretbox. This algorithm both hides the
+// content of the data and provides a check that it hasn't been altered. Output
+// takes the form nonce|ciphertext|tag where '|' indicates concatenation. The
+// output will be Overhead bytes longer than the message.
 func Encrypt(plaintext, key []byte) (ciphertext []byte, err error) {
-	if len(key) != aesKeySize {
-		return nil, aes.KeySizeError(len(key))
+	if len(key) != KeySize {
+		return nil, KeySizeError(len(key))
 	}
 
-	aes, err := aes.NewCipher(key)
+	nonce, err := generateBytes(NonceSize)
 	if err != nil {
 		return nil, err
 	}
 
-	gcm, err := cipher.NewGCM(aes)
-	if err != nil {
-		return nil, err
-	}
+	var fixedKey [KeySize]byte
+	var fixedNonce [NonceSize]byte
+	copy(fixedKey[:], key)
+	copy(fixedNonce[:], nonce)
 
-	nonce, err := generateBytes(gcm.NonceSize())
-	if err != nil {
-		return nil, err
-	}
-
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+	return secretbox.Seal(nonce, plaintext, &fixedNonce, &fixedKey), nil
 }
 
-// Decrypt decrypts data using 256-bit AES-GCM.  This both hides the content of
-// the data and provides a check that it hasn't been altered.  Expects input
-// form nonce|ciphertext|tag where '|' indicates concatenation.
+// Decrypt decrypts data using nacl secretbox. This algorithm both hides the
+// content of the data and provides a check that it hasn't been altered. Input
+// takes the form form nonce|ciphertext|tag where '|' indicates concatenation.
+// Output will be Overhead bytes shorter than the input.
 func Decrypt(ciphertext, key []byte) (plaintext []byte, err error) {
-	if len(key) != aesKeySize {
-		return nil, aes.KeySizeError(len(key))
+	if len(key) != KeySize {
+		return nil, KeySizeError(len(key))
 	}
 
-	aes, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
+	var fixedKey [KeySize]byte
+	var fixedNonce [NonceSize]byte
+	copy(fixedKey[:], key)
+	copy(fixedNonce[:], ciphertext[:NonceSize])
 
-	gcm, err := cipher.NewGCM(aes)
-	if err != nil {
-		return nil, err
+	decrypt, ok := secretbox.Open(nil, ciphertext[NonceSize:], &fixedNonce, &fixedKey)
+	if !ok {
+		return nil, errors.New("cryptopasta/encrypt: secretbox Open failed")
 	}
-
-	return gcm.Open(nil, ciphertext[:gcm.NonceSize()],
-		ciphertext[gcm.NonceSize():], nil)
+	return decrypt, nil
 }

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestEncryptDecryptGCM(t *testing.T) {
-	randomKey, err := generateBytes(aesKeySize)
+func TestEncryptDecrypt(t *testing.T) {
+	randomKey, err := GenerateEncryptionKey()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gcmTests := []struct {
+	encryptionTests := []struct {
 		plaintext []byte
 		key       []byte
 	}{
@@ -25,7 +25,7 @@ func TestEncryptDecryptGCM(t *testing.T) {
 		},
 	}
 
-	for _, tt := range gcmTests {
+	for _, tt := range encryptionTests {
 		ciphertext, err := Encrypt(tt.plaintext, tt.key)
 		if err != nil {
 			t.Fatal(err)
@@ -43,7 +43,7 @@ func TestEncryptDecryptGCM(t *testing.T) {
 		ciphertext[0] ^= 0xff
 		plaintext, err = Decrypt(ciphertext, tt.key)
 		if err == nil {
-			t.Errorf("gcmOpen should not have worked, but did")
+			t.Errorf("Open should not have worked, but did")
 		}
 	}
 }


### PR DESCRIPTION
The state of authenticated encryption has changed sufficiently to update
this recommendation. GCM looks increasingly fragile while nacl primitives are
gaining wider adoption.