### PR TITLE
Swap math/rand with crypto/rand

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -15,7 +15,7 @@ package cryptopasta
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"math/rand"
+	"crypto/rand"
 )
 
 // NewEncryptionKey generates a random 256-bit key for Encrypt() and

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -13,7 +13,7 @@ package cryptopasta
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 )
 


### PR DESCRIPTION
The current implementation with math/rand is deterministic. Run https://play.golang.org/p/CuKGup7fJR *locally* (playground seems to cache it), and switch the import back to math/rand.
See output here: https://gist.github.com/kennwhite/ba04a924e3ac279dc73e418fe2bbab98