### PR TITLE
work around goimports confusion

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -16,13 +16,14 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"io"
 )
 
 // NewEncryptionKey generates a random 256-bit key for Encrypt() and
 // Decrypt(). It panics if the source of randomness fails.
 func NewEncryptionKey() [32]byte {
 	key := [32]byte{}
-	_, err := rand.Read(key[:])
+	_, err := io.ReadFull(rand.Reader, key[:])
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +45,7 @@ func Encrypt(plaintext []byte, key [32]byte) (ciphertext []byte, err error) {
 	}
 
 	nonce := make([]byte, gcm.NonceSize())
-	_, err = rand.Read(nonce)
+	_, err = io.ReadFull(rand.Reader, nonce)
 	if err != nil {
 		return nil, err
 	}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -14,12 +14,13 @@ package cryptopasta
 import (
 	"bytes"
 	"crypto/rand"
+	"io"
 	"testing"
 )
 
 func TestEncryptDecryptGCM(t *testing.T) {
 	randomKey := [32]byte{}
-	_, err := rand.Read(randomKey[:])
+	_, err := io.ReadFull(rand.Reader, randomKey[:])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sign.go
+++ b/sign.go
@@ -31,6 +31,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
+	"io"
 	"math/big"
 )
 
@@ -38,7 +39,7 @@ import (
 // Because key generation is critical, it panics if the source of randomness fails.
 func NewHMACKey() [32]byte {
 	key := [32]byte{}
-	_, err := rand.Read(key[:])
+	_, err := io.ReadFull(rand.Reader, key[:])
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
math/rand and crypto/rand have package-level Read(b []byte) (n int, err error)

This confuses goimports under cricumstances I haven't characterised yet,
but it's a catastrophic error. Using io.ReadFull directly avoids the
issue. Thanks to Kenn White for catching this.