### PR TITLE
pass pointers to key arrays rather than the arrays themselves

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -21,19 +21,19 @@ import (
 
 // NewEncryptionKey generates a random 256-bit key for Encrypt() and
 // Decrypt(). It panics if the source of randomness fails.
-func NewEncryptionKey() [32]byte {
+func NewEncryptionKey() *[32]byte {
 	key := [32]byte{}
 	_, err := io.ReadFull(rand.Reader, key[:])
 	if err != nil {
 		panic(err)
 	}
-	return key
+	return &key
 }
 
 // Encrypt encrypts data using 256-bit AES-GCM.  This both hides the content of
 // the data and provides a check that it hasn't been altered. Output takes the
 // form nonce|ciphertext|tag where '|' indicates concatenation.
-func Encrypt(plaintext []byte, key [32]byte) (ciphertext []byte, err error) {
+func Encrypt(plaintext []byte, key *[32]byte) (ciphertext []byte, err error) {
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func Encrypt(plaintext []byte, key [32]byte) (ciphertext []byte, err error) {
 // Decrypt decrypts data using 256-bit AES-GCM.  This both hides the content of
 // the data and provides a check that it hasn't been altered. Expects input
 // form nonce|ciphertext|tag where '|' indicates concatenation.
-func Decrypt(ciphertext []byte, key [32]byte) (plaintext []byte, err error) {
+func Decrypt(ciphertext []byte, key *[32]byte) (plaintext []byte, err error) {
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return nil, err

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestEncryptDecryptGCM(t *testing.T) {
-	randomKey := [32]byte{}
+	randomKey := &[32]byte{}
 	_, err := io.ReadFull(rand.Reader, randomKey[:])
 	if err != nil {
 		t.Fatal(err)
@@ -27,7 +27,7 @@ func TestEncryptDecryptGCM(t *testing.T) {
 
 	gcmTests := []struct {
 		plaintext []byte
-		key       [32]byte
+		key       *[32]byte
 	}{
 		{
 			plaintext: []byte("Hello, world!"),

--- a/sign.go
+++ b/sign.go
@@ -37,8 +37,8 @@ import (
 
 // NewHMACKey generates a random 256-bit secret key for HMAC use.
 // Because key generation is critical, it panics if the source of randomness fails.
-func NewHMACKey() [32]byte {
-	key := [32]byte{}
+func NewHMACKey() *[32]byte {
+	key := &[32]byte{}
 	_, err := io.ReadFull(rand.Reader, key[:])
 	if err != nil {
 		panic(err)
@@ -47,7 +47,7 @@ func NewHMACKey() [32]byte {
 }
 
 // GenerateHMAC produces a symmetric signature using a shared secret key.
-func GenerateHMAC(data []byte, key [32]byte) []byte {
+func GenerateHMAC(data []byte, key *[32]byte) []byte {
 	h := hmac.New(sha512.New512_256, key[:])
 	h.Write(data)
 	return h.Sum(nil)
@@ -55,7 +55,7 @@ func GenerateHMAC(data []byte, key [32]byte) []byte {
 }
 
 // CheckHMAC securely checks the supplied MAC against a message using the shared secret key.
-func CheckHMAC(data, suppliedMAC []byte, key [32]byte) bool {
+func CheckHMAC(data, suppliedMAC []byte, key *[32]byte) bool {
 	expectedMAC := GenerateHMAC(data, key)
 	return hmac.Equal(expectedMAC, suppliedMAC)
 }

--- a/sign_test.go
+++ b/sign_test.go
@@ -44,7 +44,7 @@ func TestHMAC(t *testing.T) {
 		dataBytes, _ := hex.DecodeString(tt.data)
 		expectedDigest, _ := hex.DecodeString(tt.digest)
 
-		keyBytes := [32]byte{}
+		keyBytes := &[32]byte{}
 		copy(keyBytes[:], keySlice)
 
 		macDigest := GenerateHMAC(dataBytes, keyBytes)


### PR DESCRIPTION
Reduces the copying of key material. Thanks to @betawaffle for pointing this out, fixes #11.