### PR TITLE
Decrypt: check ciphertext length before slicing it

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -16,6 +16,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 	"io"
 )
 
@@ -65,6 +66,10 @@ func Decrypt(ciphertext []byte, key *[32]byte) (plaintext []byte, err error) {
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, errors.New("malformed ciphertext")
 	}
 
 	return gcm.Open(nil,


### PR DESCRIPTION
Prevent an index out of bounds panic caused by malformed cipher text
values by checking the length of the ciphertext before splitting out
the nonce.

cc @gtank 